### PR TITLE
Updated CMakeLists and Readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,14 @@ _*
 build
 *.ll
 *.bc
+
+# Exclude CMAKE generated files
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+
+# Exclude binary
+parser-generator
+lowc
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Copyright (c) 2015 Fabian Schuiki
-cmake_minimum_required(VERSION 3.0)
+# Copyright (c) 2015 Fabian Schuiki, Thomas Richner
+cmake_minimum_required(VERSION 2.8)
 project(low)
 
 if (CMAKE_BUILD_TYPE)
@@ -50,9 +50,9 @@ if (APPLE)
 	message(STATUS "Manually linking against LLVM libraries")
 else()
 	llvm_config(LLVM_LIBDIR --libdir)
-	find_library(LLVM_LIB NAMES LLVM LLVM-3.5 LLVM-3.6 HINTS ${LLVM_LIB_DIR} ${LLVM_HINT_PATHS} ENV LLVM_DIR PATH_SUFFIXES lib)
+	find_library(LLVM_LIB NAMES LLVM LLVM-3.5 LLVM-3.6 HINTS ${LLVM_LIBDIR} ${LLVM_HINT_PATHS} ENV LLVM_DIR PATH_SUFFIXES lib)
 	if (NOT LLVM_LIB)
-		macro(FATAL_ERROR "Unable to find libLLVM")
+		message(FATAL_ERROR "Unable to find libLLVM")
 	endif()
 	set(LLVM_LINK_FLAGS "${LLVM_LIBDIR_FLAGS} ${LLVM_LIB} ${LLVM_SYSTEM_LIBS_FLAGS}")
 	message(STATUS "Linking against shared LLVM library (${LLVM_LIB})")

--- a/README.md
+++ b/README.md
@@ -22,3 +22,11 @@ Refer to [1] and [2] for the C grammar and lexical analysis specification. Refer
 [3]: http://llvm.org/docs/LangRef.html
 [4]: http://llvm.org/doxygen/
 [5]: http://blog.golang.org/defer-panic-and-recover
+
+# Setup
+
+## Ubuntu trusty
+Install dependencies:
+```
+sudo apt-get install build-essentials llvm-3.6 llvm-3.6-dev zlib1g-dev libedit-dev
+```

--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ Refer to [1] and [2] for the C grammar and lexical analysis specification. Refer
 ## Ubuntu trusty
 Install dependencies:
 ```
-sudo apt-get install build-essentials llvm-3.6 llvm-3.6-dev zlib1g-dev libedit-dev
+sudo apt-get install build-essentials llvm-3.6 llvm-3.6-dev zlib1g-dev libedit-dev cmake
 ```


### PR DESCRIPTION
I fixed the CMakeLists partially for Ubuntu trusty and updated the Readme to help setup everything on a fresh install of Ubuntu trusty.

Changes to `CMakeLists.txt`:
- lowered minimum `cmake` to v2.8
- changed message printing with `macro(...)` to the correct `message(...)`
- fixed a `LLVM_LIB_DIR` to `LLVM_LIBDIR`
