### PR TITLE
Improved codegen for slicing

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -183,6 +183,7 @@ enum index_slice_kind {
 	AST_INDEX_SLICE_RANGE,
 	AST_INDEX_SLICE_PREFIX,
 	AST_INDEX_SLICE_POSTFIX,
+	AST_INDEX_SLICE_COPY,
 };
 
 struct index_slice_expr {

--- a/src/codegen_index_access_expr.c
+++ b/src/codegen_index_access_expr.c
@@ -110,6 +110,12 @@ CODEGEN_EXPR(index_slice_expr) {
 	LLVMValueRef target = codegen_expr(self, context, expr->index_slice.target, 0, 0);
 	LLVMValueRef zero = LLVMConstNull(LLVMInt64Type());
 
+	//---- simple copy?
+	if(expr->index_slice.kind==AST_INDEX_SLICE_COPY){
+		LLVMValueRef slice = LLVMBuildLoad(self->builder,target,"slice");
+		return slice;
+	}
+
 	//---- codegen start and end expr
 	LLVMValueRef start 	= 0;
 	LLVMValueRef end 	= 0;

--- a/src/grammar_rules.c
+++ b/src/grammar_rules.c
@@ -173,6 +173,10 @@ REDUCER(postfix_expr_slice) {
 			start = in[2].ptr;
 			end = NULL;
 			break;
+		case AST_INDEX_SLICE_COPY:
+			start = NULL;
+			end = NULL;
+			break;
 	}
 
 	e->index_slice.start 	= start;

--- a/src/grammar_rules.h
+++ b/src/grammar_rules.h
@@ -16,6 +16,7 @@ RULE(postfix_expr) \
 	VAR SUB(postfix_expr) TKN(LBRACK) SUB(expr) TKN(COLON) SUB(expr) TKN(RBRACK) REDUCE_TAG(postfix_expr_slice,0) \
 	VAR SUB(postfix_expr) TKN(LBRACK) TKN(COLON) SUB(expr) TKN(RBRACK) REDUCE_TAG(postfix_expr_slice,1) \
 	VAR SUB(postfix_expr) TKN(LBRACK) SUB(expr) TKN(COLON) TKN(RBRACK) REDUCE_TAG(postfix_expr_slice,2) \
+	VAR SUB(postfix_expr) TKN(LBRACK) TKN(COLON) TKN(RBRACK) REDUCE_TAG(postfix_expr_slice,3) \
 	VAR SUB(postfix_expr) TKN(LPAREN) TKN(RPAREN) REDUCE_TAG(postfix_expr_call, 0) \
 	VAR SUB(postfix_expr) TKN(LPAREN) SUB(argument_expr_list) TKN(RPAREN) REDUCE_TAG(postfix_expr_call, 1) \
 	VAR SUB(postfix_expr) TKN(PERIOD) TKN(IDENT) REDUCE(postfix_expr_member) \

--- a/src/lexer_tokens.h
+++ b/src/lexer_tokens.h
@@ -96,4 +96,4 @@ TKN(VAR, "var") \
 TKN(VOID, "void") \
 TKN(VOLATILE, "volatile") \
 TKN(WHILE, "while") \
-TKN(YIELD, "yield") \
+TKN(YIELD, "yield")


### PR DESCRIPTION
- fixes wrong calculation of new length
- adds 'copy' slicing e.g. `newslice = oldslice[:]`
